### PR TITLE
GHSA-4r62-v4vq-hr96 vulnerablity

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-sourcemaps": "^2.6.0",
     "inquirer": "^7.1.0",
     "keypather": "^3.0.0",
-    "marked": "^1.2.0",
+    "marked": ">=2.0.0",
     "notifications-node-client": "^4.7.2",
     "nunjucks": "^3.2.1",
     "portscanner": "^2.1.1",


### PR DESCRIPTION
REDoS in dependency Marked, https://github.com/advisories/GHSA-4r62-v4vq-hr96