### PR TITLE
Update prototype live

### DIFF
--- a/kubernetes-deploy.tpl
+++ b/kubernetes-deploy.tpl
@@ -50,7 +50,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     external-dns.alpha.kubernetes.io/set-identifier: prototype-ingress-${PROTOTYPE_NAME}-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
Add external-dns annotation to the template file, also update the host to use live domain, to get the prototype kit deployed to the new 'live' cluster

Related to:
https://github.com/ministryofjustice/cloud-platform/issues/3277