### PR TITLE
Fix prototype start up error

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,5 +2,4 @@
 
 set -eu pipefail
 
-node ./node_modules/gulp/bin/gulp generate-assets \
-  && node listen-on-port.js
+npm start


### PR DESCRIPTION
Gulp is no longer used by the GOV prototype kit so this causes an error when starting up new prototypes in CP. See https://mojdt.slack.com/archives/C57UPMZLY/p1677589810176949.